### PR TITLE
Add spec filter service and freeze table columns

### DIFF
--- a/BLTCWeb/BLTCWeb/Components/Pages/Boons.razor
+++ b/BLTCWeb/BLTCWeb/Components/Pages/Boons.razor
@@ -9,6 +9,7 @@
 <h3>Boons</h3>
 
 @inject ServerParser LogParser
+@inject SpecFilterService SpecFilter
 <LogDrawer OnUpload="StateHasChanged" />
 
 
@@ -359,21 +360,7 @@
 
     private IParsedEvtcLog[] GetFilteredLogs()
     {
-        return LogParser.BulkLog.Logs.Where(log =>
-        {
-            foreach (var player in log.GetPlayers())
-            {
-                var spec = log.GetSpec(player);
-
-                if (PlayerDisabledSpecs.TryGetValue(player, out var disabledSpecs)
-                    && disabledSpecs.Contains(spec))
-                {
-                    return false; // This log is filtered out by at least one player
-                }
-            }
-
-            return true; // No players filtered it out
-        }).ToArray();
+        return SpecFilter.FilterLogs(LogParser.BulkLog.Logs).ToArray();
     }
 
     private List<TimeSeriesChartSeries.TimeValue> CreateChartData(string Player, IParsedEvtcLog Log, int maxValue)
@@ -579,20 +566,13 @@
         OnNewData();
     }
 
-    private Dictionary<string, HashSet<string>> PlayerDisabledSpecs = new();
-
     private void TogglePlayerSpec(string playerId, string specId)
     {
-        if (!PlayerDisabledSpecs.ContainsKey(playerId))
-            PlayerDisabledSpecs[playerId] = new HashSet<string>();
-
-        if (!PlayerDisabledSpecs[playerId].Add(specId))
-            PlayerDisabledSpecs[playerId].Remove(specId);
+        SpecFilter.Toggle(playerId, specId);
     }
 
     private bool IsPlayerSpecEnabled(string playerId, string specId)
     {
-        return !PlayerDisabledSpecs.ContainsKey(playerId)
-            || !PlayerDisabledSpecs[playerId].Contains(specId);
+        return SpecFilter.IsEnabled(playerId, specId);
     }
 }

--- a/BLTCWeb/BLTCWeb/Components/Pages/DPS.razor
+++ b/BLTCWeb/BLTCWeb/Components/Pages/DPS.razor
@@ -2,9 +2,11 @@
 @using System.Net.Http.Json
 @using MudBlazor
 @using System.Globalization
+@using Bulk_Log_Comparison_Tool.DataClasses
 @rendermode InteractiveServer
 
 @inject ServerParser LogParser
+@inject SpecFilterService SpecFilter
 <LogDrawer OnUpload="StateHasChanged" />
 <div style="overflow-x: auto;">
     <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
@@ -41,7 +43,7 @@
         <HeaderContent>
             <MudTh Class="sticky-col col-1">Player</MudTh>
             <MudTh Class="sticky-col col-2">Specializations</MudTh>
-            @foreach (var log in LogParser.BulkLog.Logs)
+            @foreach (var log in GetFilteredLogs())
             {
                 <MudTh>@log.GetFileName()</MudTh>
             }
@@ -51,15 +53,25 @@
         <RowTemplate>
             <MudTd Class="sticky-col col-1">@context</MudTd>
             <MudTd Class="sticky-col col-2">
-                @foreach (var icon in imageGenerator.GetSpecializationImages(LogParser, @context))
-                {
-                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+                @{
+                    var specs = LogParser.GetPlayerSpecs(context);
+                    var images = imageGenerator.GetSpecializationImages(specs);
+                    for (int i = 0; i < specs.Length; i++)
+                    {
+                        var specId = specs[i];
+                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                        </span>
+                    }
                 }
             </MudTd>
             @{
                 var TotalDps = 0.0;
                 var TotalLogs = 0;
-                foreach (var log in LogParser.BulkLog.Logs)
+                foreach (var log in GetFilteredLogs())
                 {
                     var dps = log.GetPlayerDps(@context, _selectedPhase, _allTargets, _cumulative, _defiance);
                     <MudTd>@dps.ToString("N0", CultureInfo.CreateSpecificCulture("ru-RU"))</MudTd>
@@ -117,6 +129,11 @@
     {
         _allTargets = value;
         OnNewData();
+    }
+
+    private IParsedEvtcLog[] GetFilteredLogs()
+    {
+        return SpecFilter.FilterLogs(LogParser.BulkLog.Logs).ToArray();
     }
 
 

--- a/BLTCWeb/BLTCWeb/Components/Pages/Mechanics.razor
+++ b/BLTCWeb/BLTCWeb/Components/Pages/Mechanics.razor
@@ -1,9 +1,11 @@
 ﻿@page "/mechanics"
 @using System.Net.Http.Json
 @using MudBlazor
+@using Bulk_Log_Comparison_Tool.DataClasses
 @rendermode InteractiveServer
 
 @inject ServerParser LogParser
+@inject SpecFilterService SpecFilter
 <LogDrawer OnUpload="StateHasChanged" />
 <div style="overflow-x: auto;">
     <MudButtonGroup Color="Color.Primary" Variant="Variant.Outlined">
@@ -38,22 +40,32 @@
               LoadingProgressColor="Color.Info"
               Class="flex-table">
         <HeaderContent>
-            <MudTh>Player</MudTh>
-            <MudTh>Specializations</MudTh>
-            @foreach (var log in LogParser.BulkLog.Logs)
+            <MudTh Class="sticky-col col-1">Player</MudTh>
+            <MudTh Class="sticky-col col-2">Specializations</MudTh>
+            @foreach (var log in GetFilteredLogs())
             {
                 <MudTh>@log.GetFileName()</MudTh>
             }
         </HeaderContent>
         <RowTemplate>
-            <MudTd>@context</MudTd>
-                <MudTd>
-                    @foreach (var icon in imageGenerator.GetSpecializationImages(LogParser, @context))
-                {
-                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+            <MudTd Class="sticky-col col-1">@context</MudTd>
+            <MudTd Class="sticky-col col-2">
+                @{
+                    var specs = LogParser.GetPlayerSpecs(context);
+                    var images = imageGenerator.GetSpecializationImages(specs);
+                    for (int i = 0; i < specs.Length; i++)
+                    {
+                        var specId = specs[i];
+                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                        </span>
+                    }
                 }
             </MudTd>
-                @foreach (var log in LogParser.BulkLog.Logs)
+                @foreach (var log in GetFilteredLogs())
             {
                 var mechanics = log.GetMechanicLogs(_selectedMechanic, _selectedPhase).Where(x => x.Item1.Equals(context)).Select(x => (x.Item2 / 1000f).ToString("0.#"));
                 if(mechanics.Count() == 0)
@@ -102,6 +114,11 @@
     private void OnNewData()
     {
         StateHasChanged();
+    }
+
+    private IParsedEvtcLog[] GetFilteredLogs()
+    {
+        return SpecFilter.FilterLogs(LogParser.BulkLog.Logs).ToArray();
     }
 
     protected override void OnInitialized()

--- a/BLTCWeb/BLTCWeb/Components/Pages/Shockwaves.razor
+++ b/BLTCWeb/BLTCWeb/Components/Pages/Shockwaves.razor
@@ -8,6 +8,7 @@
 @rendermode InteractiveServer
 
 @inject ServerParser LogParser
+@inject SpecFilterService SpecFilter
 <LogDrawer OnUpload="StateHasChanged" />
 <div style="overflow-x: auto;">
     <MudGrid>
@@ -60,9 +61,9 @@
               LoadingProgressColor="MudBlazor.Color.Info"
               Class="flex-table">
         <HeaderContent>
-            <MudTh>Player</MudTh>
-            <MudTh>Specializations</MudTh>
-            @foreach (var log in LogParser.BulkLog.Logs)
+            <MudTh Class="sticky-col col-1">Player</MudTh>
+            <MudTh Class="sticky-col col-2">Specializations</MudTh>
+            @foreach (var log in GetFilteredLogs())
             {
                 if(log.GetShockwaves(0).Count() > 0){
                 <MudTh>@log.GetFileName()</MudTh>
@@ -70,14 +71,24 @@
             }
         </HeaderContent>
         <RowTemplate>
-            <MudTd>@context</MudTd>
-                <MudTd>
-                    @foreach (var icon in imageGenerator.GetSpecializationImages(LogParser, @context))
-                {
-                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+            <MudTd Class="sticky-col col-1">@context</MudTd>
+            <MudTd Class="sticky-col col-2">
+                @{
+                    var specs = LogParser.GetPlayerSpecs(context);
+                    var images = imageGenerator.GetSpecializationImages(specs);
+                    for (int i = 0; i < specs.Length; i++)
+                    {
+                        var specId = specs[i];
+                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                        </span>
+                    }
                 }
             </MudTd>
-            @foreach(var log in LogParser.BulkLog.Logs){
+            @foreach(var log in GetFilteredLogs()){
                 if(log.GetShockwaves(0).Count() > 0){
                     var data = GetImageForPlayer(log, @context);
                     if(data.Length > 0){
@@ -115,5 +126,10 @@
             shockwaves.Add((shockwave, shockwaveType));
         }
         return shockwaves;
+    }
+
+    private IParsedEvtcLog[] GetFilteredLogs()
+    {
+        return SpecFilter.FilterLogs(LogParser.BulkLog.Logs).ToArray();
     }
 }

--- a/BLTCWeb/BLTCWeb/Components/Pages/Stealth.razor
+++ b/BLTCWeb/BLTCWeb/Components/Pages/Stealth.razor
@@ -2,9 +2,11 @@
 @using System.Net.Http.Json
 @using MudBlazor
 @using Bulk_Log_Comparison_Tool.LibraryClasses
+@using Bulk_Log_Comparison_Tool.DataClasses
 @rendermode InteractiveServer
 
 @inject ServerParser LogParser
+@inject SpecFilterService SpecFilter
 <LogDrawer OnUpload="StateHasChanged" />
 
 
@@ -36,22 +38,32 @@
               LoadingProgressColor="Color.Info"
               Class="flex-table">
                 <HeaderContent>
-                    <MudTh>Player</MudTh>
-                    <MudTh>Specialization</MudTh>
-                    @foreach (var log in LogParser.BulkLog.Logs)
+                    <MudTh Class="sticky-col col-1">Player</MudTh>
+                    <MudTh Class="sticky-col col-2">Specialization</MudTh>
+                    @foreach (var log in GetFilteredLogs())
                     {
                         <MudTh>@log.GetFileName()</MudTh>
                     }
                 </HeaderContent>
                 <RowTemplate>
-                    <MudTd>@context</MudTd>
-                    <MudTd>
-                            @foreach (var icon in imageGenerator.GetSpecializationImages(LogParser, @context))
-                        {
-                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+                    <MudTd Class="sticky-col col-1">@context</MudTd>
+                    <MudTd Class="sticky-col col-2">
+                        @{
+                            var specs = LogParser.GetPlayerSpecs(context);
+                            var images = imageGenerator.GetSpecializationImages(specs);
+                            for (int i = 0; i < specs.Length; i++)
+                            {
+                                var specId = specs[i];
+                                var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                                var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                                <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                                </span>
+                            }
                         }
                     </MudTd>
-                    @foreach (var log in LogParser.BulkLog.Logs)
+                    @foreach (var log in GetFilteredLogs())
                     {
                         <MudTd>@log.GetStealthResult(@context, Bulk_Log_Comparison_Tool.Enums.StealthAlgoritmns.OutlierFiltering).FirstOrDefault(x => x.Item1.Equals(_selectedPhase)).Item2</MudTd>
                     }
@@ -209,5 +221,10 @@
     {
         Graph,
         Table
+    }
+
+    private IParsedEvtcLog[] GetFilteredLogs()
+    {
+        return SpecFilter.FilterLogs(LogParser.BulkLog.Logs).ToArray();
     }
 }

--- a/BLTCWeb/BLTCWeb/Components/Pages/Summary.razor
+++ b/BLTCWeb/BLTCWeb/Components/Pages/Summary.razor
@@ -9,6 +9,7 @@
 
 <h3>Summary</h3>
 @inject ServerParser LogParser
+@inject SpecFilterService SpecFilter
 <LogDrawer OnUpload="StateHasChanged" />
 <div style="overflow-x: auto;">
 
@@ -61,19 +62,29 @@
                     LoadingProgressColor="Color.Info"
                     Class="flex-table">
                         <HeaderContent>
-                            <MudTh>Player</MudTh>
-                            <MudTh>Specialization</MudTh>
+                            <MudTh Class="sticky-col col-1">Player</MudTh>
+                            <MudTh Class="sticky-col col-2">Specialization</MudTh>
                             @foreach (var phase in latestLog?.GetStealthPhases() ?? [])
                             {
                                 <MudTh>@phase</MudTh>
                             }
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd>@context</MudTd>
-                            <MudTd>
-                                @foreach (var icon in imageGenerator.GetSpecializationImages([latestLog.GetSpec(context)]))
-                                {
-                                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+                            <MudTd Class="sticky-col col-1">@context</MudTd>
+                            <MudTd Class="sticky-col col-2">
+                                @{
+                                    var specs = new[] { latestLog.GetSpec(context) };
+                                    var images = imageGenerator.GetSpecializationImages(specs);
+                                    for (int i = 0; i < specs.Length; i++)
+                                    {
+                                        var specId = specs[i];
+                                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                                        </span>
+                                    }
                                 }
                             </MudTd>
                             @foreach (var phase in latestLog?.GetStealthPhases() ?? [])
@@ -97,8 +108,8 @@
                     LoadingProgressColor="Color.Info"
                     Class="flex-table">
                         <HeaderContent>
-                            <MudTh>Player</MudTh>
-                            <MudTh>Specialization</MudTh>
+                            <MudTh Class="sticky-col col-1">Player</MudTh>
+                            <MudTh Class="sticky-col col-2">Specialization</MudTh>
                             @foreach (var mechanic in selectedMechanics)
                             {
                                 if (mechanic.Value)
@@ -108,11 +119,21 @@
                             }
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd>@context</MudTd>
-                            <MudTd>
-                                @foreach (var icon in imageGenerator.GetSpecializationImages([latestLog.GetSpec(context)]))
-                                {
-                                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+                            <MudTd Class="sticky-col col-1">@context</MudTd>
+                            <MudTd Class="sticky-col col-2">
+                                @{
+                                    var specs = new[] { latestLog.GetSpec(context) };
+                                    var images = imageGenerator.GetSpecializationImages(specs);
+                                    for (int i = 0; i < specs.Length; i++)
+                                    {
+                                        var specId = specs[i];
+                                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                                        </span>
+                                    }
                                 }
                             </MudTd>
                             @foreach (var mechanic in selectedMechanics)
@@ -139,16 +160,26 @@
                     LoadingProgressColor="MudBlazor.Color.Info"
                     Class="flex-table">
                         <HeaderContent>
-                            <MudTh>Player</MudTh>
-                            <MudTh>Specializations</MudTh>
+                            <MudTh Class="sticky-col col-1">Player</MudTh>
+                            <MudTh Class="sticky-col col-2">Specializations</MudTh>
                             <MudTh>Shockwaves</MudTh>
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd>@context</MudTd>
-                            <MudTd>
-                                @foreach (var icon in imageGenerator.GetSpecializationImages([latestLog.GetSpec(context)]))
-                                {
-                                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+                            <MudTd Class="sticky-col col-1">@context</MudTd>
+                            <MudTd Class="sticky-col col-2">
+                                @{
+                                    var specs = new[] { latestLog.GetSpec(context) };
+                                    var images = imageGenerator.GetSpecializationImages(specs);
+                                    for (int i = 0; i < specs.Length; i++)
+                                    {
+                                        var specId = specs[i];
+                                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                                        </span>
+                                    }
                                 }
                             </MudTd>
                             @if (latestLog.GetShockwaves(0).Count() > 0)
@@ -183,16 +214,26 @@
                     LoadingProgressColor="Color.Info"
                     Class="flex-table">
                         <HeaderContent>
-                            <MudTh>Player</MudTh>
-                            <MudTh>Specializations</MudTh>
+                            <MudTh Class="sticky-col col-1">Player</MudTh>
+                            <MudTh Class="sticky-col col-2">Specializations</MudTh>
                             <MudTh>Downs</MudTh>
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd>@context</MudTd>
-                            <MudTd>
-                                @foreach (var icon in imageGenerator.GetSpecializationImages([latestLog.GetSpec(context)]))
-                                {
-                                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+                            <MudTd Class="sticky-col col-1">@context</MudTd>
+                            <MudTd Class="sticky-col col-2">
+                                @{
+                                    var specs = new[] { latestLog.GetSpec(context) };
+                                    var images = imageGenerator.GetSpecializationImages(specs);
+                                    for (int i = 0; i < specs.Length; i++)
+                                    {
+                                        var specId = specs[i];
+                                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                                        </span>
+                                    }
                                 }
                             </MudTd>
                             @foreach (var downReason in latestLog.GetDownReasons(context)){
@@ -215,16 +256,26 @@
                     LoadingProgressColor="Color.Info"
                     Class="flex-table">
                         <HeaderContent>
-                            <MudTh>Player</MudTh>
-                            <MudTh>Specializations</MudTh>
+                            <MudTh Class="sticky-col col-1">Player</MudTh>
+                            <MudTh Class="sticky-col col-2">Specializations</MudTh>
                             <MudTh>Defiance damage</MudTh>
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd>@context</MudTd>
-                            <MudTd>
-                                @foreach (var icon in imageGenerator.GetSpecializationImages([latestLog.GetSpec(context)]))
-                                {
-                                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+                            <MudTd Class="sticky-col col-1">@context</MudTd>
+                            <MudTd Class="sticky-col col-2">
+                                @{
+                                    var specs = new[] { latestLog.GetSpec(context) };
+                                    var images = imageGenerator.GetSpecializationImages(specs);
+                                    for (int i = 0; i < specs.Length; i++)
+                                    {
+                                        var specId = specs[i];
+                                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                                        </span>
+                                    }
                                 }
                             </MudTd>
                             <MudTd>@latestLog.GetPlayerDps(@context, "Full Fight", true, true, true).ToString("N0", CultureInfo.CreateSpecificCulture("ru-RU"))</MudTd>
@@ -245,17 +296,27 @@
                     LoadingProgressColor="Color.Info"
                     Class="flex-table">
                         <HeaderContent>
-                            <MudTh>Player</MudTh>
-                            <MudTh>Specializations</MudTh>
+                            <MudTh Class="sticky-col col-1">Player</MudTh>
+                            <MudTh Class="sticky-col col-2">Specializations</MudTh>
                             <MudTh>Giants</MudTh>
                             <MudTh>Goliath</MudTh>
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd>@context</MudTd>
-                            <MudTd>
-                                @foreach (var icon in imageGenerator.GetSpecializationImages([latestLog.GetSpec(context)]))
-                                {
-                                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+                            <MudTd Class="sticky-col col-1">@context</MudTd>
+                            <MudTd Class="sticky-col col-2">
+                                @{
+                                    var specs = new[] { latestLog.GetSpec(context) };
+                                    var images = imageGenerator.GetSpecializationImages(specs);
+                                    for (int i = 0; i < specs.Length; i++)
+                                    {
+                                        var specId = specs[i];
+                                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                                        </span>
+                                    }
                                 }
                             </MudTd>
                             <MudTd>@latestLog.GetPlayerDps(@context, "Giants", true, true, false).ToString("N0", CultureInfo.CreateSpecificCulture("ru-RU"))</MudTd>
@@ -277,8 +338,8 @@
                     LoadingProgressColor="Color.Info"
                     Class="flex-table">
                         <HeaderContent>
-                            <MudTh>Player</MudTh>
-                            <MudTh>Specializations</MudTh>
+                            <MudTh Class="sticky-col col-1">Player</MudTh>
+                            <MudTh Class="sticky-col col-2">Specializations</MudTh>
                             @foreach (var boon in latestLog.GetBoonNames())
                             {
 
@@ -286,11 +347,21 @@
                             }
                         </HeaderContent>
                         <RowTemplate>
-                            <MudTd>@context</MudTd>
-                            <MudTd>
-                                @foreach (var icon in imageGenerator.GetSpecializationImages([latestLog.GetSpec(context)]))
-                                {
-                                    <MudImage ObjectPosition="@ObjectPosition.Center" Src="@String.Format("data:image/png;base64,{0}", Convert.ToBase64String(icon.BytesFromImage()))" />
+                            <MudTd Class="sticky-col col-1">@context</MudTd>
+                            <MudTd Class="sticky-col col-2">
+                                @{
+                                    var specs = new[] { latestLog.GetSpec(context) };
+                                    var images = imageGenerator.GetSpecializationImages(specs);
+                                    for (int i = 0; i < specs.Length; i++)
+                                    {
+                                        var specId = specs[i];
+                                        var filter = SpecFilter.IsEnabled(context, specId) ? "none" : "grayscale(1) opacity(0.5)";
+                                        var style = $"cursor:pointer; margin-right:4px; filter:{filter};";
+
+                                        <span style="@style" @onclick="@(() => SpecFilter.Toggle(context, specId))">
+                                            <MudImage ObjectPosition="@ObjectPosition.Center" Src="@($"data:image/png;base64,{Convert.ToBase64String(images[i].BytesFromImage())}")" />
+                                        </span>
+                                    }
                                 }
                             </MudTd>
                             @foreach(var boon in latestLog.GetBoonNames())

--- a/BLTCWeb/BLTCWeb/Program.cs
+++ b/BLTCWeb/BLTCWeb/Program.cs
@@ -24,6 +24,7 @@ namespace BLCTWeb
                 .AddInteractiveWebAssemblyComponents()
                 .AddInteractiveServerComponents();
             builder.Services.AddScoped<ServerParser>();
+            builder.Services.AddScoped<SpecFilterService>();
 #if DEBUG
             builder.Services.Configure<CircuitOptions>(options =>
             {

--- a/BLTCWeb/BLTCWeb/SpecFilterService.cs
+++ b/BLTCWeb/BLTCWeb/SpecFilterService.cs
@@ -1,0 +1,41 @@
+using Bulk_Log_Comparison_Tool.DataClasses;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BLCTWeb
+{
+    public class SpecFilterService
+    {
+        private readonly Dictionary<string, HashSet<string>> _disabledSpecs = new();
+
+        public void Toggle(string playerId, string specId)
+        {
+            if (!_disabledSpecs.ContainsKey(playerId))
+                _disabledSpecs[playerId] = new HashSet<string>();
+
+            if (!_disabledSpecs[playerId].Add(specId))
+                _disabledSpecs[playerId].Remove(specId);
+        }
+
+        public bool IsEnabled(string playerId, string specId)
+        {
+            return !_disabledSpecs.ContainsKey(playerId) || !_disabledSpecs[playerId].Contains(specId);
+        }
+
+        public IEnumerable<IParsedEvtcLog> FilterLogs(IEnumerable<IParsedEvtcLog> logs)
+        {
+            return logs.Where(log =>
+            {
+                foreach (var player in log.GetPlayers())
+                {
+                    var spec = log.GetSpec(player);
+                    if (_disabledSpecs.TryGetValue(player, out var disabled) && disabled.Contains(spec))
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `SpecFilterService` to manage disabling specializations
- register the service in the web application
- apply sticky column styling and clickable spec icons on multiple pages

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688a81bdcb848326ae3e318e8efcef7e