### PR TITLE
Fix sorting and sticky columns

### DIFF
--- a/BLTCWeb/BLTCWeb/Components/Pages/Boons.razor
+++ b/BLTCWeb/BLTCWeb/Components/Pages/Boons.razor
@@ -185,7 +185,7 @@
                 {
                     <MudTh @onclick="() => OnSort(log.GetFileName())" Style="cursor:pointer">@log.GetFileName()</MudTh>
                 }
-                <MudTh>Average</MudTh>
+                <MudTh @onclick='() => OnSort("Average")' Style="cursor:pointer">Average</MudTh>
             </HeaderContent>
             <RowTemplate>
                 @if (_showPlayersDict.ContainsKey(context) && _showPlayersDict[context])
@@ -372,12 +372,31 @@
         var players = LogParser.BulkLog.GetPlayers().AsEnumerable();
         if (!string.IsNullOrEmpty(_sortColumn))
         {
-            var log = LogParser.BulkLog.Logs.FirstOrDefault(l => l.GetFileName() == _sortColumn);
-            if (log != null)
+            if (_sortColumn == "Average")
             {
                 players = _sortDescending
-                    ? players.OrderByDescending(p => log.GetBoon(p, _selectedBoon, _selectedPhase))
-                    : players.OrderBy(p => log.GetBoon(p, _selectedBoon, _selectedPhase));
+                    ? players.OrderByDescending(p =>
+                        {
+                            var logs = GetFilteredLogs();
+                            var values = logs.Select(l => l.GetBoon(p, _selectedBoon, _selectedPhase)).Where(v => v > 0);
+                            return values.Any() ? values.Average() : 0;
+                        })
+                    : players.OrderBy(p =>
+                        {
+                            var logs = GetFilteredLogs();
+                            var values = logs.Select(l => l.GetBoon(p, _selectedBoon, _selectedPhase)).Where(v => v > 0);
+                            return values.Any() ? values.Average() : 0;
+                        });
+            }
+            else
+            {
+                var log = LogParser.BulkLog.Logs.FirstOrDefault(l => l.GetFileName() == _sortColumn);
+                if (log != null)
+                {
+                    players = _sortDescending
+                        ? players.OrderByDescending(p => log.GetBoon(p, _selectedBoon, _selectedPhase))
+                        : players.OrderBy(p => log.GetBoon(p, _selectedBoon, _selectedPhase));
+                }
             }
         }
         return players;

--- a/BLTCWeb/BLTCWeb/Components/Pages/DPS.razor
+++ b/BLTCWeb/BLTCWeb/Components/Pages/DPS.razor
@@ -48,7 +48,7 @@
             {
                 <MudTh @onclick="() => OnSort(log.GetFileName())" Style="cursor:pointer">@log.GetFileName()</MudTh>
             }
-            <MudTh>Average</MudTh>
+            <MudTh @onclick='() => OnSort("Average")' Style="cursor:pointer">Average</MudTh>
 
         </HeaderContent>
         <RowTemplate>
@@ -155,12 +155,31 @@
         var players = LogParser.BulkLog.GetPlayers().AsEnumerable();
         if (!string.IsNullOrEmpty(_sortColumn))
         {
-            var log = LogParser.BulkLog.Logs.FirstOrDefault(l => l.GetFileName() == _sortColumn);
-            if (log != null)
+            if (_sortColumn == "Average")
             {
                 players = _sortDescending
-                    ? players.OrderByDescending(p => log.GetPlayerDps(p, _selectedPhase, _allTargets, _cumulative, _defiance))
-                    : players.OrderBy(p => log.GetPlayerDps(p, _selectedPhase, _allTargets, _cumulative, _defiance));
+                    ? players.OrderByDescending(p =>
+                        {
+                            var logs = GetFilteredLogs();
+                            var values = logs.Select(l => l.GetPlayerDps(p, _selectedPhase, _allTargets, _cumulative, _defiance)).Where(v => v > 0);
+                            return values.Any() ? values.Average() : 0;
+                        })
+                    : players.OrderBy(p =>
+                        {
+                            var logs = GetFilteredLogs();
+                            var values = logs.Select(l => l.GetPlayerDps(p, _selectedPhase, _allTargets, _cumulative, _defiance)).Where(v => v > 0);
+                            return values.Any() ? values.Average() : 0;
+                        });
+            }
+            else
+            {
+                var log = LogParser.BulkLog.Logs.FirstOrDefault(l => l.GetFileName() == _sortColumn);
+                if (log != null)
+                {
+                    players = _sortDescending
+                        ? players.OrderByDescending(p => log.GetPlayerDps(p, _selectedPhase, _allTargets, _cumulative, _defiance))
+                        : players.OrderBy(p => log.GetPlayerDps(p, _selectedPhase, _allTargets, _cumulative, _defiance));
+                }
             }
         }
         return players;

--- a/BLTCWeb/BLTCWeb/wwwroot/app.css
+++ b/BLTCWeb/BLTCWeb/wwwroot/app.css
@@ -67,11 +67,13 @@ h1:focus {
 
 .col-1 {
     left: 0;
+    width: 150px;
     min-width: 150px;
 }
 
 .col-2 {
     left: 150px; /* sum of all previous sticky widths */
+    width: 120px;
     min-width: 120px;
     box-shadow: 2px 0 4px rgba(0, 0, 0, 0.05); /* lighter shadow for second col */
 }


### PR DESCRIPTION
## Summary
- allow sorting by the Average column on DPS and Boons pages
- keep first two columns sticky by giving them fixed widths

## Testing
- `dotnet test` *(fails: GetDamageReductionsAtTime_ReturnsArray, HasStabDuringShockwave_ReturnsBool, GetShockwaves_ReturnsArray, GetStealthTimeline_ReturnsCollection, GetStealthResult_ReturnsList, GetPhases_ReturnsExpectedPhases, GetPlayerDps_FullFightAllTargets_SumsAllTargets, GetBoon_ByGroup_ReturnsExpectedValue)*

------
https://chatgpt.com/codex/tasks/task_b_688a96ff1ee08326a5fb0eb068718fb0